### PR TITLE
Fix create_user

### DIFF
--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -156,15 +156,14 @@ class Schoology:
         """
         return User(self._get(('users/' + ('inactive/' if inactive else '') + '%s') % user_id))
 
-    def create_user(self, user, user_id):
+    def create_user(self, user):
         """
         Create a new user.
 
         :param user: User object containing necessary fields.
-        :param user_id: ID of user you wish to create.
         :return: User object obtained from API.
         """
-        return User(self._post('users/%s' % user_id, user))
+        return User(self._post('users', user))
 
     def create_users(self, users):
         """


### PR DESCRIPTION
Removed user_id parameter from the create_user method in main, and removed reference to it, which will correct the method from leading to an invalid endpoint.

There are two user IDs used by Schoology:
 "id" which is the internal Schoology ID assigned by Schoology when a user is created and not user definable... this is the id which is used by the API for requests related to users.
"school_id" which is user definable and a required parameter at the time of user creation.  

The current behavior of create_user wants "id" as an argument (user_id)... but this can't be satisfied for new users since it is assigned by Schoology during account creation... and will not lead to a valid endpoint.  User creation has to be done via POST at the root level of https://api.schoology.com/v1/users.  The "school_id" should be included as an attribute of the user object.