### PR TITLE
New method for obtaining grades

### DIFF
--- a/schoolopy/authentication.py
+++ b/schoolopy/authentication.py
@@ -3,7 +3,12 @@ import time
 import requests_oauthlib
 from requests_oauthlib.oauth1_session import TokenRequestDenied
 from oauthlib.common import urldecode
-from urllib import parse
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
 
 
 class AuthorizationError(Exception):
@@ -69,7 +74,7 @@ class Auth:
             self.request_token_secret = fetch_response.get('oauth_token_secret')
 
         base_authorization_url = self.DOMAIN_ROOT + '/oauth/authorize'
-        return self.oauth.authorization_url(base_authorization_url, request_token=self.request_token) + '&' + parse.urlencode({'oauth_callback': self.DOMAIN_ROOT})
+        return self.oauth.authorization_url(base_authorization_url, request_token=self.request_token) + '&' + urlencode({'oauth_callback': self.DOMAIN_ROOT})
 
     def authorize(self):
         if self.authorized or not self.three_legged:

--- a/schoolopy/authentication.py
+++ b/schoolopy/authentication.py
@@ -4,6 +4,15 @@ import requests_oauthlib
 from requests_oauthlib.oauth1_session import TokenRequestDenied
 from oauthlib.common import urldecode
 
+"""
+Suppress InsecureRequestWarning
+https://stackoverflow.com/questions/27981545/suppress-insecurerequestwarning-unverified-https-request-is-being-made-in-pytho
+"""
+#from requests.packages.urllib3.exceptions import InsecureRequestWarning
+#requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 try:
     from urllib.parse import urlencode
 except ImportError:

--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -23,19 +23,20 @@ class Schoology:
         self.secret = schoology_auth.consumer_secret
         self.schoology_auth = schoology_auth
 
-    def _get(self, path, query=None):
+    def _get(self, path, query=''):
         """
         GET data from a given endpoint.
 
         :param path: Path (following API root) to endpoint.
         :return: JSON response.
         """
-        earl = url='%s%s?limit=%s%s' % (self._ROOT, path, self.limit, query)
+        url = '%s%s?limit=%s%s' % (self._ROOT, path, self.limit, query)
         try:
             response = self.schoology_auth.oauth.get(
-                url=earl, headers=self.schoology_auth._request_header(),
+                url=url, headers=self.schoology_auth._request_header(),
                 auth=self.schoology_auth.oauth.auth
             )
+            #print(response.__dict__)
             return response.json()
         except JSONDecodeError:
             return {}
@@ -304,6 +305,8 @@ class Schoology:
             return self.get_section_enrollments(section_id)
         elif group_id:
             return self.get_group_enrollments(group_id)
+        elif course_id:
+            return self.get_course_enrollments(course_id)
         else:
             raise TypeError('Realm id property required.')
 
@@ -312,6 +315,9 @@ class Schoology:
 
     def get_group_enrollments(self, group_id):
         return [Enrollment(raw) for raw in self._get('groups/%s/enrollments' % group_id)['enrollment']]
+
+    def get_course_enrollments(self, course_id):
+        return [Enrollment(raw) for raw in self._get('course/%s/enrollments' % course_id)['enrollment']]
 
 
     # TODO: Do we need to provide the ID of the realm?
@@ -1918,6 +1924,14 @@ class Schoology:
 
     def get_friend_request(self, user_id, request_id):
         return FriendRequest(self._get('users/%s/requests/friends/%s' % (user_id, request_id)))
+
+    def get_user_grades(self, section_id):
+
+        return [
+            Grade(raw) for raw in self._get(
+                'users/{}/grades'.format(section_id)
+            )['grades']['grade']
+        ]
 
     def get_user_section_invites(self, user_id):
         return [Invite(raw) for raw in self._get('users/%s/invites/sections' % user_id)['invite']]

--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -1893,33 +1893,23 @@ class Schoology:
     # TODO: Support Web Content Package
     # TODO: Support Completion
 
-    def get_section_grades(self, section_id, query_name=None, query_value=None):
+    def get_section_grades(self, section_id, query=None):
         """
         Returns a list of grades (paged).
 
         :param section_id: ID of course's section.
-        :return: a list of grades for that section.
-
-        The following optional query strings can be appended to the path
-        to filter results:
-
-        :param query_name (timestamp, assignment_id, or enrollment_id)
-        :param query_value
-
-        timestamp:      return only grades that have been changed since
-                        the given timestamp, according to the server time.
-                        e.g. "timestamp": 1517551200
-        assignment_id:  filter grades for a given assignment
-        enrollment_id:  filter grades for a given enrollment
+        :param query: name/value pairs in HTTP GET form.
+        :return: a list of grades.
         """
 
-        query = ''
-        if query_name and query_value:
-            query = '&{}={}'.format(query_name, query_value)
+        if query and isinstance(query ,dict):
+            get = ''
+            for key, value in query.items():
+                get += '&{}={}'.format(key, value)
 
         return [
             Grade(raw) for raw in self._get(
-                'sections/{}/grades'.format(section_id), query
+                'sections/{}/grades'.format(section_id), get
             )['grades']['grade']
         ]
 
@@ -1930,7 +1920,7 @@ class Schoology:
         return FriendRequest(self._get('users/%s/requests/friends/%s' % (user_id, request_id)))
 
     def get_user_section_invites(self, user_id):
-        return [Invite(raw) for raw in self._get('users/{}/invites/sections'.format(user_id))['invite']]
+        return [Invite(raw) for raw in self._get('users/%s/invites/sections' % user_id)['invite']]
 
     def get_user_group_invites(self, user_id):
         return [Invite(raw) for raw in self._get('users/%s/invites/groups' % user_id)['invite']]

--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -3,6 +3,11 @@ from .authentication import AuthorizationError
 import time
 import json
 
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 
 class Schoology:
     _ROOT = 'https://api.schoology.com/v1/'
@@ -28,7 +33,7 @@ class Schoology:
         try:
             response = self.schoology_auth.oauth.get(url='%s%s?limit=%s' % (self._ROOT, path, self.limit), headers=self.schoology_auth._request_header(), auth=self.schoology_auth.oauth.auth)
             return response.json()
-        except json.decoder.JSONDecodeError:
+        except JSONDecodeError:
             return {}
 
     def _post(self, path, data):
@@ -41,7 +46,7 @@ class Schoology:
         """
         try:
             return self.schoology_auth.oauth.post(url='%s%s?limit=%s' % (self._ROOT, path, self.limit), json=data, headers=self.schoology_auth._request_header(), auth=self.schoology_auth.oauth.auth).json()
-        except json.decoder.JSONDecodeError:
+        except JSONDecodeError:
             return {}
 
     def _put(self, path, data):
@@ -54,7 +59,7 @@ class Schoology:
         """
         try:
             return self.schoology_auth.oauth.put(url='%s%s?limit=%s' % (self._ROOT, path, self.limit), json=data, headers=self.schoology_auth._request_header(), auth=self.schoology_auth.oauth.auth).json()
-        except json.decoder.JSONDecodeError:
+        except JSONDecodeError:
             return {}
 
     def _delete(self, path):


### PR DESCRIPTION
we created a new method for obtain grades based on section_id. the grades API endpoint allows you to further filter the results with GET query name/value pairs for: timestamp, enrollment_id, and assignment_id. in order to take advantage of that, we updated the _get() method to allow for an optional query value that is added after the "limit" name/value pair.

the _get() method could remain unmodified if that limit value were not added there. if you would rather remove the bit where the "limit" GET variable is added to the URL, i'd be happy to go that route as well.