### PR TITLE
Add PyPi description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,13 @@
 
 from setuptools import setup
 
+with open('README.rst', 'r') as fh:
+      long_description = fh.read()
+
 setup(name='schoolopy',
-      version='0.2.0',
+      version='0.2.2',
       description='A Python wrapper for Schoology\'s API.',
+      long_description=long_description,
       url='https://github.com/ErikBoesen/schoolopy',
       author='Erik Boesen',
       author_email='me@erikboesen.com',


### PR DESCRIPTION
It now has a description on pypi. Before, this is what you saw on PyPi's description:

> The author of this package has not provided a project description

Now it should have the README.rst contents.