### PR TITLE
Add get_comment_likes method

### DIFF
--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -2060,6 +2060,16 @@ class Schoology:
         """
         return self._unlike('like/%s/comment/%s' % (id, comment_id))
 
+    def get_comment_likes(self, id, comment_id):
+        """
+        Get all users who have liked a comment on an object.
+
+        :param id: ID of object on which the comment was written.
+        :param comment_id: ID of comment to check likes of.
+        :return List of users who have liked the comment.
+        """
+        return [User(raw) for raw in self._get('like/%s/comment/%s' % (id, comment_id))['users']]
+    
     def vote(self, poll_id, choice_id):
         """
         Cast a vote on a poll.


### PR DESCRIPTION
Thanks for this! I'm making something that works with [Likes](https://developers.schoology.com/api-documentation/rest-api-v1/like) on Schoology. Although there is a `like_comment` and `unlike_comment` method, there doesn't seem to be a method to list all likes on a comment. This adds a method that would be able to list comment likes just as with listing likes on an object using the `get_likes` method.