### PR TITLE
Fix Update & UpdateComment methods

### DIFF
--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -1329,15 +1329,15 @@ class Schoology:
         return Update(self._post('groups/%s/updates' % group_id, comment.json()))
 
 
-    def get_update_comments(self, comment, update_id, user_id=None, section_id=None, group_id=None):
+    def get_update_comments(self, update_id, user_id=None, section_id=None, group_id=None):
         """
-        Helper function for creating a comment on an update in any realm.
+        Get data on update comments in any realm.
 
         :param update_id: ID of update from which to get comments.
         :param *_id: ID of realm.
         """
         if user_id:
-            return self.get_user_update_comments(update_id, district_id)
+            return self.get_user_update_comments(update_id, user_id)
         elif section_id:
             return self.get_section_update_comments(update_id, section_id)
         elif group_id:
@@ -1364,7 +1364,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            return self.get_user_update_comment(comment_id, update_id, district_id)
+            return self.get_user_update_comment(comment_id, update_id, user_id)
         elif section_id:
             return self.get_section_update_comment(comment_id, update_id, section_id)
         elif group_id:

--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -1328,6 +1328,7 @@ class Schoology:
     def create_group_update(self, comment, update_id, group_id):
         return Update(self._post('groups/%s/updates/%s/comments' % (group_id, update_id), comment.json()))
 
+
     def get_update_comments(self, update_id, user_id=None, section_id=None, group_id=None):
         """
         Get data on update comments in any realm.

--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -1197,9 +1197,9 @@ class Schoology:
         if user_id:
             self.get_user_updates(user_id)
         elif section_id:
-            self.get_user_updates(section_id)
+            self.get_section_updates(section_id)
         elif group_id:
-            self.get_user_updates(group_id)
+            self.get_group_updates(group_id)
         else:
             raise TypeError('Realm id property required.')
 
@@ -1284,7 +1284,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            return self.update_district_update(update, district_id)
+            return self.update_user_update(update, district_id)
         elif section_id:
             return self.update_section_update(update, section_id)
         elif group_id:
@@ -1292,13 +1292,13 @@ class Schoology:
         else:
             raise TypeError('Realm id property required.')
 
-    def update_district_update(update, district_id):
-        return Update(self._put('districts/%s/updates' % district_id, update.json()))
+    def update_user_update(self, update, user_id):
+        return Update(self._put('users/%s/updates' % user_id, update.json()))
 
-    def update_section_update(update, section_id):
+    def update_section_update(self, update, section_id):
         return Update(self._put('sections/%s/updates' % section_id, update.json()))
 
-    def update_group_update(update, group_id):
+    def update_group_update(self, update, group_id):
         return Update(self._put('groups/%s/updates' % group_id, update.json()))
 
 
@@ -1311,7 +1311,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            return self.create_user_update_comment(comment, update_id, district_id)
+            return self.create_user_update_comment(comment, update_id, user_id)
         elif section_id:
             return self.create_section_update_comment(comment, update_id, section_id)
         elif group_id:
@@ -1319,15 +1319,14 @@ class Schoology:
         else:
             raise TypeError('Realm id property required.')
 
-    def create_district_update(update, district_id):
-        return Update(self._post('districts/%s/updates' % district_id, comment.json()))
+    def create_user_update_comment(self, comment, update_id, user_id):
+        return Update(self._post('users/%s/updates/%s/comments' % (user_id, update_id), comment.json()))
 
-    def create_section_update(update, section_id):
-        return Update(self._post('sections/%s/updates' % section_id, comment.json()))
+    def create_section_update_comment(self, comment, update_id, section_id):
+        return Update(self._post('sections/%s/updates/%s/comments' % (section_id, update_id), comment.json()))
 
-    def create_group_update(update, group_id):
-        return Update(self._post('groups/%s/updates' % group_id, comment.json()))
-
+    def create_group_update(self, comment, update_id, group_id):
+        return Update(self._post('groups/%s/updates/%s/comments' % (group_id, update_id), comment.json()))
 
     def get_update_comments(self, update_id, user_id=None, section_id=None, group_id=None):
         """
@@ -1391,7 +1390,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            self.delete_user_update_comment(comment_id, update_id, district_id)
+            self.delete_user_update_comment(comment_id, update_id, user_id)
         elif section_id:
             self.delete_section_update_comment(comment_id, update_id, section_id)
         elif group_id:

--- a/schoolopy/main.py
+++ b/schoolopy/main.py
@@ -1170,7 +1170,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            self.create_district_update(update, district_id)
+            self.create_user_update(update, user_id)
         elif section_id:
             self.create_school_update(update, school_id)
         elif group_id:
@@ -1178,13 +1178,13 @@ class Schoology:
         else:
             raise TypeError('Realm id property required.')
 
-    def create_district_update(update, district_id):
-        return Update(self._post('districts/%s/updates' % district_id, update.json()))
+    def create_user_update(self, update, user_id):
+        return Update(self._post('users/%s/updates' % user_id, update.json()))
 
-    def create_section_update(update, section_id):
+    def create_section_update(self, update, section_id):
         return Update(self._post('sections/%s/updates' % section_id, update.json()))
 
-    def create_group_update(update, group_id):
+    def create_group_update(self, update, group_id):
         return Update(self._post('groups/%s/updates' % group_id, update.json()))
 
 
@@ -1232,7 +1232,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            self.get_user_update(update_id, district_id)
+            self.get_user_update(update_id, user_id)
         elif section_id:
             self.get_section_update(update_id, section_id)
         elif group_id:
@@ -1258,7 +1258,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            self.delete_user_update(update_id, district_id)
+            self.delete_user_update(update_id, user_id)
         elif section_id:
             self.delete_section_update(update_id, section_id)
         elif group_id:
@@ -1284,7 +1284,7 @@ class Schoology:
         :param *_id: ID of realm.
         """
         if user_id:
-            return self.update_user_update(update, district_id)
+            return self.update_user_update(update, user_id)
         elif section_id:
             return self.update_section_update(update, section_id)
         elif group_id:
@@ -1383,10 +1383,10 @@ class Schoology:
 
     def delete_update_comment(self, comment_id, update_id, user_id=None, section_id=None, group_id=None):
         """
-        Get data on an update comment in any realm.
+        Delete an update comment in any realm.
 
-        :param comment_id: ID of comment on which to get data.
-        :param update_id: ID of update on which to create comment.
+        :param comment_id: ID of comment to delete.
+        :param update_id: ID of update on which to delete comment.
         :param *_id: ID of realm.
         """
         if user_id:


### PR DESCRIPTION
There seems to be some misuse of the District realm with the [Update](https://developers.schoology.com/api-documentation/rest-api-v1/updates) and [Update Comment](https://developers.schoology.com/api-documentation/rest-api-v1/update-comment) objects which only take User, Section, or Group as realm. This should fix those methods.

It appears also that all POST methods are broken? I am not entirely sure, but it seems like `.json()` formats to single quotes which is not valid for the `json=` parameter in the POST request. They might need to be updated. However, I am not quite sure how to approach it. Thanks! :sparkles: